### PR TITLE
fix: improve YAML parser error handling and update docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Tools
+Copyright (c) 2021 SV Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 The [conf](https://github.com/sv-tools/conf) parser for YAML format.
 
+```shell
+go get github.com/sv-tools/conf-parser-yaml
+```
 
 ## License
 

--- a/go.sum
+++ b/go.sum
@@ -12,14 +12,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
-github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/sv-tools/conf v1.3.0 h1:efYrEHeHQu5uaeqL7gVu5oP19M9ksckUnbZON4RrGYI=
-github.com/sv-tools/conf v1.3.0/go.mod h1:fogkBBqNOnCyvQeU6kZuDw/dMtw4qyOQBJXgh+P47Zo=
 github.com/sv-tools/conf v1.4.0 h1:IT/6x899dsSe9mv/oBAKqKpPVpL/0Q1gkSk0iPr2mvY=
 github.com/sv-tools/conf v1.4.0/go.mod h1:l4wXlwHUJtPjsgT2KIZVC0LrgleMRiQFD0eMoMb5o9I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/parser.go
+++ b/parser.go
@@ -2,22 +2,23 @@ package confyaml
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Parser is a conf.ParseFunc to parse the given yaml
-func Parser(ctx context.Context, r io.Reader) (interface{}, error) {
+func Parser(_ context.Context, r io.Reader) (any, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read data: %w", err)
 	}
 
-	var res interface{}
+	var res any
 	if err := yaml.Unmarshal(data, &res); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse yaml: %w", err)
 	}
 
-	return res, ctx.Err()
+	return res, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -44,7 +44,7 @@ func TestParserErrors(t *testing.T) {
 	require.ErrorIs(t, c.Load(t.Context()), errFake)
 
 	c = conf.New().WithReaders(conf.NewStreamParser(strings.NewReader(wrongData)).WithParser(confyaml.Parser))
-	require.EqualError(t, c.Load(t.Context()), "yaml: line 1: did not find expected key")
+	require.ErrorContains(t, c.Load(t.Context()), "yaml: line 1: did not find expected key")
 }
 
 func ExampleParser() {


### PR DESCRIPTION
Enhance the YAML parser to wrap errors with descriptive messages for
read and parse failures, improving debugging clarity. Update the test
to check for error substring instead of exact match, making tests
more robust. Correct copyright holder in LICENSE and add installation
instructions to README for better user guidance.