### PR TITLE
chore: Go version and adjust workflow permissions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,8 +8,7 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   UnitTests:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sv-tools/conf-parser-yaml
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
Update Go version from 1.24.0 to 1.24 for consistency with toolchain standards. Modify GitHub Actions workflow permissions to use read-all instead of contents: read, enabling broader access required for CI checks.